### PR TITLE
Typo Fix in Modifier Key info window

### DIFF
--- a/MacsyZones/TrayPopup.swift
+++ b/MacsyZones/TrayPopup.swift
@@ -740,7 +740,7 @@ struct Main: View {
                  return Alert(
                     title: Text("Modifier Key"),
                     message: Text("""
-                        Modifier key is mainly for performing snap resize but you can also use it to snap your windowst to your zones.
+                        Modifier key is mainly for performing snap resize but you can also use it to snap your windows to your zones.
                     
                         Modifier key has a delay that you can adjust; when you press and hold the modifier key, MacsyZones will start to show you the zones with snap resizers between them.
                     


### PR DESCRIPTION
Just a one-character fix for a typo I saw in the "Modifier Key" information window:

![image](https://github.com/user-attachments/assets/634a568d-f13a-45da-b393-4435844fcd92)

(BTW: thank you for making this too, I've been wating a long time for FancyZones on the Mac!)