### PR TITLE
Adds installation method: Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ https://github.com/user-attachments/assets/101d3296-889f-4cfb-93cf-87bad548a108
 
 https://github.com/user-attachments/assets/5b26c5cf-90f3-4ace-b324-b2f6404c3ea8
 
+### Install with Homebrew
+
+You can install MacsyZones via [Homebrew](https://brew.sh):
+
+```sh
+brew install --cask macsyzones
+```
+
 ## Buy to support me
 
 You can buy MacsyZones Pro (the same MacsyZones just "Pro") to support me.


### PR DESCRIPTION
This adds installation instructions for MacsyZones via Homebrew Cask to the README.

MacsyZones was added to the official Homebrew cask repository in [Homebrew/homebrew-cask@4ecefc6](https://github.com/Homebrew/homebrew-cask/commit/4ecefc6ffd0d48489ec889597acba2d4ab471b39). The cask uses GitHub releases as the download source, as opposed to the website download URL which is not versioned (versioned URLs are preferred by homebrew).
