### PR TITLE
Fix: preserve config symlinks when saving settings

### DIFF
--- a/MacsyZones/ProLock.swift
+++ b/MacsyZones/ProLock.swift
@@ -76,7 +76,7 @@ class ProLock: ObservableObject {
         let filePath = appDirectory.appendingPathComponent(licenseFileName)
         
         do {
-            try licenseKey.write(to: filePath, atomically: true, encoding: .utf8)
+            try licenseKey.write(to: filePath, atomically: false, encoding: .utf8)
             debugLog("License key saved")
         } catch {
             debugLog("Error saving license key: \(error)")

--- a/MacsyZones/UserData.swift
+++ b/MacsyZones/UserData.swift
@@ -127,7 +127,7 @@ class UserData {
         let filePath = appDirectory.appendingPathComponent(fileName)
         
         do {
-            try data.write(to: filePath, atomically: true, encoding: .utf8)
+            try data.write(to: filePath, atomically: false, encoding: .utf8)
         } catch (let error) {
             debugLog("Error saving user data: \(error)")
         }


### PR DESCRIPTION
Hi, I allowed myself to make a small contribution to this awesome project! :)

## Summary

This PR fixes settings persistence so MacsyZones no longer replaces symbolic links with regular files when saving user data.

The app was writing settings with `String.write(..., atomically: true)`. On macOS, atomic writes replace the destination path, which breaks symlinks and leaves a plain file in their place. This is a problem for users who intentionally manage config files through symlinks.

## Why this matters

A practical example is managing app configuration with GNU Stow.

With Stow, config files can live in a version-controlled dotfiles repository and be exposed into their expected runtime locations as symlinks. That makes it easy to:
- keep configuration under source control
- sync settings across machines
- review changes in one canonical location
- rebuild a setup quickly on a new machine

In this workflow, the app should write through the symlink to the target file, not replace the symlink itself.

## Changes

- Changed settings writes from atomic to non-atomic in the shared `UserData` persistence layer
- Changed license key writes from atomic to non-atomic for the same reason

## Result

After this change:
- if the config path is a symlink, MacsyZones preserves the symlink and updates the target file
- if no symlink exists, MacsyZones still creates a normal file as before

## Notes

I verified the underlying behavior locally:
- `atomically: true` replaces a symlink with a regular file
- `atomically: false` preserves the symlink and writes to its target
