### PR TITLE
[codex] Add verified opt-in update installs

### DIFF
--- a/MacsyZones/App.swift
+++ b/MacsyZones/App.swift
@@ -223,8 +223,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, Sen
                     updateState.clearUpdateAttempt()
                 }
             }
-            
-            appUpdater.checkForUpdates()
+
+            if appSettings.automaticallyCheckForUpdates {
+                appUpdater.checkForUpdates(download: appSettings.automaticallyInstallUpdates)
+            }
         }
     }
     

--- a/MacsyZones/Popover.swift
+++ b/MacsyZones/Popover.swift
@@ -640,6 +640,27 @@ struct Main: View {
                                 updateStartAtLoginState()
                             }
                     }
+
+                    Divider().padding(.vertical, 2)
+
+                    Toggle("Check for updates automatically", isOn: $settings.automaticallyCheckForUpdates)
+                        .toggleStyle(.checkbox)
+                        .onChange(of: settings.automaticallyCheckForUpdates) { enabled in
+                            if !enabled {
+                                settings.automaticallyInstallUpdates = false
+                            }
+
+                            appSettings.save()
+
+                            if enabled {
+                                updater.checkForUpdates(download: settings.automaticallyInstallUpdates)
+                            }
+                        }
+
+                    Toggle("Install verified updates automatically", isOn: $settings.automaticallyInstallUpdates)
+                        .toggleStyle(.checkbox)
+                        .disabled(!settings.automaticallyCheckForUpdates)
+                        .onChange(of: settings.automaticallyInstallUpdates) { _ in appSettings.save() }
                 }
                 .fixedSize()
             }
@@ -668,7 +689,19 @@ struct Main: View {
             #endif
             
             HStack {
-                Button(action: { updater.checkForUpdates() }) {
+                Button(action: {
+                    if updater.isUpdatable == true {
+                        if settings.automaticallyInstallUpdates {
+                            updater.checkForUpdates(download: true)
+                        } else if let releaseURL = updater.latestReleaseURL {
+                            NSWorkspace.shared.open(releaseURL)
+                        } else {
+                            updater.checkForUpdates()
+                        }
+                    } else {
+                        updater.checkForUpdates(download: settings.automaticallyInstallUpdates)
+                    }
+                }) {
                     HStack {
                         if updater.isChecking {
                             Image(systemName: "arrow.clockwise.circle")
@@ -677,8 +710,13 @@ struct Main: View {
                             ProgressView().font(.system(size: 12))
                             Text("Downloading...")
                         } else if let isUpdatable = updater.isUpdatable, let latestVersion = updater.latestVersion, isUpdatable {
-                            Image(systemName: "arrow.down.circle.fill")
-                            Text("Update to \(latestVersion)")
+                            if settings.automaticallyInstallUpdates {
+                                Image(systemName: "arrow.down.circle.fill")
+                                Text("Install \(latestVersion)")
+                            } else {
+                                Image(systemName: "arrow.up.right.square")
+                                Text("Open \(latestVersion) Release")
+                            }
                         } else {
                             Image(systemName: "arrow.clockwise.circle")
                             Text("Check for Updates")

--- a/MacsyZones/Popover.swift
+++ b/MacsyZones/Popover.swift
@@ -690,7 +690,9 @@ struct Main: View {
             
             HStack {
                 Button(action: {
-                    if updater.isUpdatable == true {
+                    if updater.updateErrorMessage != nil, let releaseURL = updater.latestReleaseURL {
+                        NSWorkspace.shared.open(releaseURL)
+                    } else if updater.isUpdatable == true {
                         if settings.automaticallyInstallUpdates {
                             updater.checkForUpdates(download: true)
                         } else if let releaseURL = updater.latestReleaseURL {
@@ -709,6 +711,9 @@ struct Main: View {
                         } else if updater.isDownloading {
                             ProgressView().font(.system(size: 12))
                             Text("Downloading...")
+                        } else if updater.updateErrorMessage != nil, let latestVersion = updater.latestVersion {
+                            Image(systemName: "arrow.up.right.square")
+                            Text("Open \(latestVersion) Release")
                         } else if let isUpdatable = updater.isUpdatable, let latestVersion = updater.latestVersion, isUpdatable {
                             if settings.automaticallyInstallUpdates {
                                 Image(systemName: "arrow.down.circle.fill")
@@ -751,6 +756,13 @@ struct Main: View {
             }
             .fixedSize()
             .padding(.top, 5)
+
+            if let updateErrorMessage = updater.updateErrorMessage {
+                Text(updateErrorMessage)
+                    .font(.caption)
+                    .foregroundColor(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .frame(minWidth: 400)
         .fixedSize()

--- a/MacsyZones/Settings.swift
+++ b/MacsyZones/Settings.swift
@@ -30,6 +30,8 @@ struct AppSettingsData: Codable {
     var cycleWindowsForwardShortcut: String?
     var cycleWindowsBackwardShortcut: String?
     var snapHighlightStrategy: SnapHighlightStrategy?
+    var automaticallyCheckForUpdates: Bool?
+    var automaticallyInstallUpdates: Bool?
 }
 
 class AppSettings: UserData, ObservableObject {
@@ -51,6 +53,8 @@ class AppSettings: UserData, ObservableObject {
     private static let defaultCycleWindowsForwardShortcut: String = "Command+]"
     private static let defaultCycleWindowsBackwardShortcut: String = "Command+["
     private static let defaultSnapHighlightStrategy: SnapHighlightStrategy = .centerProximity
+    private static let defaultAutomaticallyCheckForUpdates: Bool = true
+    private static let defaultAutomaticallyInstallUpdates: Bool = false
     
     @Published var modifierKey: String = defaultModifierKey
     @Published var snapKey: String = defaultSnapKey
@@ -69,6 +73,8 @@ class AppSettings: UserData, ObservableObject {
     @Published var cycleWindowsForwardShortcut: String = defaultCycleWindowsForwardShortcut
     @Published var cycleWindowsBackwardShortcut: String = defaultCycleWindowsBackwardShortcut
     @Published var snapHighlightStrategy: SnapHighlightStrategy = defaultSnapHighlightStrategy
+    @Published var automaticallyCheckForUpdates: Bool = defaultAutomaticallyCheckForUpdates
+    @Published var automaticallyInstallUpdates: Bool = defaultAutomaticallyInstallUpdates
 
     init() {
         super.init(name: "AppSettings", data: "{}", fileName: "AppSettings.json")
@@ -99,6 +105,8 @@ class AppSettings: UserData, ObservableObject {
             self.cycleWindowsForwardShortcut = settings.cycleWindowsForwardShortcut ?? cycleWindowsForwardShortcut
             self.cycleWindowsBackwardShortcut = settings.cycleWindowsBackwardShortcut ?? cycleWindowsBackwardShortcut
             self.snapHighlightStrategy = settings.snapHighlightStrategy ?? snapHighlightStrategy
+            self.automaticallyCheckForUpdates = settings.automaticallyCheckForUpdates ?? automaticallyCheckForUpdates
+            self.automaticallyInstallUpdates = settings.automaticallyInstallUpdates ?? automaticallyInstallUpdates
         } catch {
             debugLog("Error parsing settings JSON: \(error)")
         }
@@ -123,7 +131,9 @@ class AppSettings: UserData, ObservableObject {
                 showSnapResizersOnHover: showSnapResizersOnHover,
                 cycleWindowsForwardShortcut: cycleWindowsForwardShortcut,
                 cycleWindowsBackwardShortcut: cycleWindowsBackwardShortcut,
-                snapHighlightStrategy: snapHighlightStrategy
+                snapHighlightStrategy: snapHighlightStrategy,
+                automaticallyCheckForUpdates: automaticallyCheckForUpdates,
+                automaticallyInstallUpdates: automaticallyInstallUpdates
             )
             
             let jsonData = try JSONEncoder().encode(settings)
@@ -155,6 +165,8 @@ class AppSettings: UserData, ObservableObject {
         cycleWindowsForwardShortcut = Self.defaultCycleWindowsForwardShortcut
         cycleWindowsBackwardShortcut = Self.defaultCycleWindowsBackwardShortcut
         snapHighlightStrategy = Self.defaultSnapHighlightStrategy
+        automaticallyCheckForUpdates = Self.defaultAutomaticallyCheckForUpdates
+        automaticallyInstallUpdates = Self.defaultAutomaticallyInstallUpdates
         
         if #available(macOS 12.0, *) {
             quickSnapper.toggleHotkey?.register(for: quickSnapShortcut)

--- a/MacsyZones/Settings.swift
+++ b/MacsyZones/Settings.swift
@@ -111,6 +111,10 @@ class AppSettings: UserData, ObservableObject {
             self.automaticallyCheckForUpdates = settings.automaticallyCheckForUpdates ?? automaticallyCheckForUpdates
             self.automaticallyInstallUpdates = settings.automaticallyInstallUpdates ?? automaticallyInstallUpdates
             self.enableLayoutSwitcher = settings.enableLayoutSwitcher ?? enableLayoutSwitcher
+
+            if !automaticallyCheckForUpdates {
+                automaticallyInstallUpdates = false
+            }
         } catch {
             debugLog("Error parsing settings JSON: \(error)")
         }

--- a/MacsyZones/Updater.swift
+++ b/MacsyZones/Updater.swift
@@ -30,12 +30,14 @@ class AppUpdater: ObservableObject {
     
     @Published var latestVersion: String?
     @Published var latestReleaseURL: URL?
+    @Published var updateErrorMessage: String?
     
     let updater = GitHubUpdater()
     
     func checkForUpdates(download: Bool = false) {
         Task { @MainActor in
             self.isChecking = true
+            self.updateErrorMessage = nil
         }
         
         updater.checkForUpdates(download: download) { release in
@@ -62,6 +64,10 @@ class AppUpdater: ObservableObject {
             Task { @MainActor in
                 self.isChecking = false
                 self.isDownloading = false
+
+                if !success {
+                    self.updateErrorMessage = "Update install failed. Open the release manually."
+                }
             }
         }
     }
@@ -191,13 +197,12 @@ class GitHubUpdater {
                 return
             }
             
-            onCompleted?(true)
-            
-            self.extractZip(from: tmpPath, version: version)
+            let success = self.extractZip(from: tmpPath, version: version)
+            onCompleted?(success)
         }
     }
     
-    private func extractZip(from zipURL: URL, version: String) {
+    private func extractZip(from zipURL: URL, version: String) -> Bool {
         let fileManager = FileManager.default
         let destinationFolder = getApplicationsPath()
         let destinationApp = destinationFolder.appendingPathComponent("MacsyZones.app")
@@ -216,7 +221,7 @@ class GitHubUpdater {
             guard fileManager.fileExists(atPath: extractedAppURL.path) else {
                 debugLog("Error: Extracted app not found.")
                 try? fileManager.removeItem(at: tempDirectory)
-                return
+                return false
             }
             
             let extractedInfoPlist = extractedAppURL.appendingPathComponent("Contents/Info.plist")
@@ -225,7 +230,7 @@ class GitHubUpdater {
                   let targetVersion = extractedPlist["CFBundleShortVersionString"] as? String else {
                 debugLog("Error: Could not read target version from extracted app.")
                 try? fileManager.removeItem(at: tempDirectory)
-                return
+                return false
             }
 
             let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
@@ -234,24 +239,24 @@ class GitHubUpdater {
             guard targetBundleIdentifier == expectedUpdaterBundleIdentifier else {
                 debugLog("Error: Extracted app bundle identifier does not match MacsyZones.")
                 try? fileManager.removeItem(at: tempDirectory)
-                return
+                return false
             }
 
             guard targetVersion == version else {
                 debugLog("Error: Extracted app version does not match the GitHub release version.")
                 try? fileManager.removeItem(at: tempDirectory)
-                return
+                return false
             }
 
             guard isVersionGreater(targetVersion, than: currentVersion) else {
                 debugLog("Error: Extracted app is not newer than the current app.")
                 try? fileManager.removeItem(at: tempDirectory)
-                return
+                return false
             }
 
             guard hasValidCodeSignature(at: extractedAppURL) else {
                 try? fileManager.removeItem(at: tempDirectory)
-                return
+                return false
             }
 
             updateState.setUpdateAttempt(currentVersion: currentVersion, targetVersion: targetVersion)
@@ -308,9 +313,12 @@ class GitHubUpdater {
                     NSApp.terminate(nil)
                 }
             }
+
+            return true
         } catch {
             debugLog("Update error: \(error.localizedDescription)")
             try? fileManager.removeItem(at: tempDirectory)
+            return false
         }
     }
 

--- a/MacsyZones/Updater.swift
+++ b/MacsyZones/Updater.swift
@@ -10,7 +10,18 @@
 // See LICENSE file.
 //
 
+import AppKit
 import Foundation
+import Security
+
+private let expectedUpdaterBundleIdentifier = "MeowingCat.MacsyZones"
+private let expectedUpdaterTeamIdentifier = "59CP56H446"
+
+struct GitHubRelease {
+    let version: String
+    let releaseURL: URL
+    let downloadURL: URL?
+}
 
 class AppUpdater: ObservableObject {
     @Published var isChecking = false
@@ -18,6 +29,7 @@ class AppUpdater: ObservableObject {
     @Published var isDownloading = false
     
     @Published var latestVersion: String?
+    @Published var latestReleaseURL: URL?
     
     let updater = GitHubUpdater()
     
@@ -26,11 +38,13 @@ class AppUpdater: ObservableObject {
             self.isChecking = true
         }
         
-        updater.checkForUpdates { version in
-            guard let version = version else {
+        updater.checkForUpdates(download: download) { release in
+            guard let release = release else {
                 Task { @MainActor in
                     self.isChecking = false
                     self.isDownloading = false
+                    self.latestVersion = nil
+                    self.latestReleaseURL = nil
                     self.isUpdatable = false
                 }
                 
@@ -38,10 +52,11 @@ class AppUpdater: ObservableObject {
             }
             
             Task { @MainActor in
-                self.latestVersion = version
+                self.latestVersion = release.version
+                self.latestReleaseURL = release.releaseURL
                 self.isChecking = false
                 self.isUpdatable = true
-                self.isDownloading = true
+                self.isDownloading = download
             }
         } onDownloaded: { success in
             Task { @MainActor in
@@ -88,7 +103,7 @@ func getApplicationsPath() -> URL {
 class GitHubAPI {
     let session = URLSession.shared
 
-    func checkLatestRelease(onChecked: @escaping ((version: String, url: URL)?) -> Void) {
+    func checkLatestRelease(onChecked: @escaping (GitHubRelease?) -> Void) {
         let urlString = "https://api.github.com/repos/rohanrhu/MacsyZones/releases/latest"
         guard let url = URL(string: urlString) else {
             onChecked(nil)
@@ -104,14 +119,23 @@ class GitHubAPI {
             do {
                 if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
                    let tagName = json["tag_name"] as? String,
-                   let assets = json["assets"] as? [[String: Any]],
-                   let downloadUrl = assets.first?["browser_download_url"] as? String
+                   let releaseURLString = json["html_url"] as? String
                 {
                     let version = tagName.replacingOccurrences(of: "v", with: "")
-                    let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as! String
+                    let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
                     let isGreater = isVersionGreater(version, than: appVersion)
-                    
-                    onChecked(isGreater ? (version: version, url: URL(string: downloadUrl)!): nil)
+                    let downloadURLString = ((json["assets"] as? [[String: Any]])?.first?["browser_download_url"] as? String)
+
+                    guard isGreater, let releaseURL = URL(string: releaseURLString) else {
+                        onChecked(nil)
+                        return
+                    }
+
+                    onChecked(GitHubRelease(
+                        version: version,
+                        releaseURL: releaseURL,
+                        downloadURL: downloadURLString.flatMap(URL.init(string:))
+                    ))
                 } else {
                     onChecked(nil)
                 }
@@ -132,16 +156,26 @@ class GitHubUpdater {
     let applicationsDirectory = NSSearchPathForDirectoriesInDomains(.applicationDirectory, .userDomainMask, true).first!
     let appName = "MacsyZones"
     
-    func checkForUpdates(onChecked: ((String?) -> Void)? = nil, onDownloaded: ((Bool) -> Void)? = nil) {
+    func checkForUpdates(download: Bool = false, onChecked: ((GitHubRelease?) -> Void)? = nil, onDownloaded: ((Bool) -> Void)? = nil) {
         githubAPI.checkLatestRelease { [self] latestRelease in
             guard let latestRelease else {
                 onChecked?(nil)
                 return
             }
+
+            onChecked?(latestRelease)
+
+            guard download else {
+                return
+            }
+
+            guard let downloadURL = latestRelease.downloadURL else {
+                debugLog("Error: Latest release does not include a downloadable app asset.")
+                onDownloaded?(false)
+                return
+            }
             
-            onChecked?(latestRelease.version)
-            
-            self.downloadZip(from: latestRelease.url, version: latestRelease.version) { success in
+            self.downloadZip(from: downloadURL, version: latestRelease.version) { success in
                 onDownloaded?(success)
             }
         }
@@ -159,11 +193,11 @@ class GitHubUpdater {
             
             onCompleted?(true)
             
-            self.extractZip(from: tmpPath)
+            self.extractZip(from: tmpPath, version: version)
         }
     }
     
-    private func extractZip(from zipURL: URL) {
+    private func extractZip(from zipURL: URL, version: String) {
         let fileManager = FileManager.default
         let destinationFolder = getApplicationsPath()
         let destinationApp = destinationFolder.appendingPathComponent("MacsyZones.app")
@@ -193,16 +227,40 @@ class GitHubUpdater {
                 try? fileManager.removeItem(at: tempDirectory)
                 return
             }
-            
+
             let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
-            
+            let targetBundleIdentifier = extractedPlist["CFBundleIdentifier"] as? String
+
+            guard targetBundleIdentifier == expectedUpdaterBundleIdentifier else {
+                debugLog("Error: Extracted app bundle identifier does not match MacsyZones.")
+                try? fileManager.removeItem(at: tempDirectory)
+                return
+            }
+
+            guard targetVersion == version else {
+                debugLog("Error: Extracted app version does not match the GitHub release version.")
+                try? fileManager.removeItem(at: tempDirectory)
+                return
+            }
+
+            guard isVersionGreater(targetVersion, than: currentVersion) else {
+                debugLog("Error: Extracted app is not newer than the current app.")
+                try? fileManager.removeItem(at: tempDirectory)
+                return
+            }
+
+            guard hasValidCodeSignature(at: extractedAppURL) else {
+                try? fileManager.removeItem(at: tempDirectory)
+                return
+            }
+
             updateState.setUpdateAttempt(currentVersion: currentVersion, targetVersion: targetVersion)
             
             let scriptURL = tempDirectory.appendingPathComponent("update.sh")
             let script = """
             #!/bin/bash
             sleep 2
-            
+
             # Remove quarantine from extracted app (prevents GateKeeper issues)
             xattr -r -d com.apple.quarantine "\(extractedAppURL.path)" 2>/dev/null || true
             
@@ -211,7 +269,7 @@ class GitHubUpdater {
             
             # Use ditto to preserve extended attributes during move
             ditto "\(extractedAppURL.path)" "\(destinationApp.path)"
-            
+
             # Final quarantine cleanup on installed app
             xattr -r -d com.apple.quarantine "\(destinationApp.path)" 2>/dev/null || true
             
@@ -254,6 +312,41 @@ class GitHubUpdater {
             debugLog("Update error: \(error.localizedDescription)")
             try? fileManager.removeItem(at: tempDirectory)
         }
+    }
+
+    private func hasValidCodeSignature(at appURL: URL) -> Bool {
+        var staticCode: SecStaticCode?
+        let createStatus = SecStaticCodeCreateWithPath(appURL as CFURL, SecCSFlags(), &staticCode)
+
+        guard createStatus == errSecSuccess, let staticCode = staticCode else {
+            debugLog("Error: Could not read update code signature. OSStatus: \(createStatus)")
+            return false
+        }
+
+        let validationFlags = SecCSFlags(rawValue: kSecCSCheckAllArchitectures | kSecCSStrictValidate | kSecCSCheckNestedCode)
+        let validationStatus = SecStaticCodeCheckValidity(staticCode, validationFlags, nil)
+
+        guard validationStatus == errSecSuccess else {
+            debugLog("Error: Update code signature is invalid. OSStatus: \(validationStatus)")
+            return false
+        }
+
+        var signingInfo: CFDictionary?
+        let infoStatus = SecCodeCopySigningInformation(staticCode, SecCSFlags(rawValue: kSecCSSigningInformation), &signingInfo)
+
+        guard infoStatus == errSecSuccess,
+              let info = signingInfo as? [String: Any],
+              let teamIdentifier = info[kSecCodeInfoTeamIdentifier as String] as? String else {
+            debugLog("Error: Could not read update signing team. OSStatus: \(infoStatus)")
+            return false
+        }
+
+        guard teamIdentifier == expectedUpdaterTeamIdentifier else {
+            debugLog("Error: Update signing team does not match MacsyZones.")
+            return false
+        }
+
+        return true
     }
 }
 

--- a/MacsyZones/Updater.swift
+++ b/MacsyZones/Updater.swift
@@ -127,10 +127,11 @@ class GitHubAPI {
                    let tagName = json["tag_name"] as? String,
                    let releaseURLString = json["html_url"] as? String
                 {
+                    let assets = json["assets"] as? [[String: Any]]
                     let version = tagName.replacingOccurrences(of: "v", with: "")
                     let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
                     let isGreater = isVersionGreater(version, than: appVersion)
-                    let downloadURLString = ((json["assets"] as? [[String: Any]])?.first?["browser_download_url"] as? String)
+                    let downloadURLString = Self.selectDownloadURLString(from: assets)
 
                     guard isGreater, let releaseURL = URL(string: releaseURLString) else {
                         onChecked(nil)
@@ -153,6 +154,22 @@ class GitHubAPI {
         }
         
         task.resume()
+    }
+
+    private static func selectDownloadURLString(from assets: [[String: Any]]?) -> String? {
+        guard let assets = assets else {
+            return nil
+        }
+
+        let namedZip = assets.first { asset in
+            (asset["name"] as? String)?.caseInsensitiveCompare("MacsyZones.zip") == .orderedSame
+        }
+
+        let anyZip = assets.first { asset in
+            ((asset["name"] as? String)?.lowercased().hasSuffix(".zip") ?? false)
+        }
+
+        return (namedZip ?? anyZip ?? assets.first)?["browser_download_url"] as? String
     }
 }
 


### PR DESCRIPTION
## Summary
- keep automatic update checks enabled by default, but make automatic installation an explicit opt-in setting
- preserve the existing updater install flow for users who opt in, while wiring the existing download flag so check-only paths do not download assets
- require extracted update apps to match the MacsyZones bundle id, release version, newer version, valid code signature, and expected Apple team id before replacement is attempted
- keep the existing quarantine-stripping steps in the updater script for the valid auto-update install scenario
- surface install/download/verification failures in the popover and route the update button to the release page after a failed install attempt
- keep older settings files compatible by defaulting missing fields and normalizing the impossible state where install is enabled while update checks are disabled
- select the release zip by `MacsyZones.zip` first, then any `.zip`, then the old first-asset fallback so updater behavior does not depend on GitHub asset ordering

## Why
This supersedes #72. That PR removed the download/install updater path entirely, which was too broad: it made the default safer but regressed users who want automatic updates. This branch keeps the behavior split explicit: check by default, install only when opted in and verified.

## Compatibility / safety
- Default behavior remains backwards-compatible for existing users: update checks stay enabled and automatic install stays disabled unless explicitly opted in.
- Existing auto-update behavior remains available for users who opt in, including the previous quarantine cleanup path.
- Older settings JSON without the new fields still loads through nil-coalesced defaults.
- The release asset fallback still supports older release layouts if a future release does not name the zip exactly `MacsyZones.zip`.
- The v3.0.1 release asset was inspected without launching it: `MacsyZones.zip` extracts to `MacsyZones.app`, bundle id `MeowingCat.MacsyZones`, version `3.0.1`, min macOS `11.5`, universal `x86_64 arm64`, signed by team `59CP56H446`, and `codesign --verify --deep --strict` passes.
- Manual local validation reported by @lmachineone: a locally source-built PR version successfully updated to the latest `3.0.1` release and kept working.

## Validation
- `awk` guard confirmed `downloadZip` no longer reports success before extraction/verification finishes
- `git diff --check HEAD^..HEAD`
- `git diff --check upstream/main...HEAD`
- `xcrun swiftc -typecheck -target arm64-apple-macosx11.5 -import-objc-header MacsyZones-Bridging-Header.h MacsyZones/*.swift`
- `xcrun swiftc -typecheck -target x86_64-apple-macosx11.5 -import-objc-header MacsyZones-Bridging-Header.h MacsyZones/*.swift`
- `xcodebuild -project MacsyZones.xcodeproj -scheme MacsyZones -configuration Debug -derivedDataPath ./DerivedData -destination 'platform=macOS,arch=arm64' CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM= CODE_SIGN_IDENTITY=- build`
- `xcodebuild -project MacsyZones.xcodeproj -scheme MacsyZones -configuration Debug -derivedDataPath ./DerivedData-x86_64 -destination 'platform=macOS,arch=x86_64' CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM= CODE_SIGN_IDENTITY=- build`

Codex downloaded/extracted the release zip only to inspect metadata and signature. Codex did not launch the release app, install it, or run the auto-replacement path. The remaining maintainer-requested coverage is real auto-update validation on additional machines.
